### PR TITLE
Issue-20: Added inital trimmed down version of breakpoint mixin

### DIFF
--- a/scss/library/_breakpoint.scss
+++ b/scss/library/_breakpoint.scss
@@ -238,9 +238,3 @@ $smallest-unit: 1px;
     }
   }
 }
-
-body {
-  @include breakpoint('medium', 'and up', 2) {
-    background: white;
-  }
-}


### PR DESCRIPTION
I trimmed down the original a bit already, but still left most of the features. This will be a good starting point to trim down from if we want something that's a bit smart, if we want something very simple, we'd be better off starting from scratch.

Features (that could be cut to reduce size/complexity):
- Breakpoints are stored in a list var with human friendly names
- Can define query to be breakpoint and up, and down, or just the specified breakpoint (e.g. `'small', 'and up'`, or `'large', 'and down'`, or just `'large'`)
- Can define what pixel density you'd like
- Error reporting is breakpoint doesn't exist
- Breakpoint debug mixin that will add a short tag to the top left corner to tell you which breakpoint you're currently viewing

**Original's documentation**
http://codepen.io/wesruv/full/eIpuv/
'-minor' and '-major' breakpoints were removed.

**Original Issue**
https://github.com/Lullabot/windup/issues/20
