### PR TITLE
Corrects reference to skin sass directory.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
         files: {
           'scss/_component.scss': 'scss/component/**/*.scss',
           'scss/_layout.scss': 'scss/layout/**/*.scss',
-          'scss/_skin.scss': 'scss/layout/**/*.scss'
+          'scss/_skin.scss': 'scss/skin/**/*.scss'
         }
       },
       options: {


### PR DESCRIPTION
I discovered that style inside the `scss/layout` was being included twice in `style.css`.
https://github.com/Lullabot/windup/issues/35#issuecomment-85028596

This should fix that. Yay!