### PR TITLE
Issue #55: Updates template_preprocess_node().

### DIFF
--- a/windup.theme
+++ b/windup.theme
@@ -23,6 +23,30 @@ function windup_preprocess_html(&$variables, $hook) {
   }
 }
 
+function windup_preprocess_node(&$variables, $hook) {
+  // Add an unpublished variable
+  $variables['unpublished'] = FALSE;
+  if ($variables['node']->isPublished() != TRUE) {
+    $variables['unpublished'] = TRUE;
+  }
+
+}
+
+/**
+ * Implements hook_theme_suggestions_alter().
+ */
+function windup_theme_suggestions_alter(array &$suggestions, array $variables, $hook) {
+
+  // Create a page suggestion per content type.
+  if ($hook === 'page') {
+    if ($node = \Drupal::routeMatch()->getParameter('node')) {
+      $content_type = $node->bundle();
+      $suggestions[] = 'page__' . $content_type;
+    }
+  }
+
+}
+
 /**
  * Implements template_preprocess_menu_local_task().
  */


### PR DESCRIPTION
This commit drops a lot of old functionality from the 7.x branch.

We no longer strictly need an "unpublished" class. Partly because D8's
attribute array makes a node--published class available and partly
because we could just use the node object's isPublished() method. I've
left the code for it in place as an example of how it could be done.

The theme hook suggestions were dropped from preprocess_node since D8
actually already has most of the suggestions we were adding in 7.x.
I did create some theme suggestions for the page templates however based
on the entity type. This is done with hook_theme_suggestions_alter().
