### PR TITLE
Issue #58: Updates template_preprocess_comment().

### DIFF
--- a/templates/content/comment.html.twig
+++ b/templates/content/comment.html.twig
@@ -64,8 +64,17 @@
  * @see template_preprocess_comment()
  */
 #}
-
-<article{{ attributes.addClass('js-comment') }}>
+{%
+  set classes = [
+    'comment',
+    'comment--' ~ commented_entity.getEntityTypeId(),
+    'js-comment',
+    status != 'comment--published' ? status,
+    comment.owner.anonymous ? 'comment--by-anonymous',
+    author_id and author_id == commented_entity.getOwnerId() ? 'comment--by-' ~ commented_entity.getEntityTypeId() ~ '-author'
+  ]
+%}
+<article{{ attributes.addClass(classes) }}>
   {#
     Hide the "new" indicator by default, let a piece of JavaScript ask the
     server which comments are new for the user. Rendering the final "new"
@@ -73,9 +82,9 @@
   #}
   <mark class="hidden" data-comment-timestamp="{{ new_indicator_timestamp }}"></mark>
 
-  <footer>
-    {{ user_picture }}
-    <p>{{ submitted }}</p>
+  <footer class="comment__footer">
+    <div class="comment__author-image">{{ user_picture }}</div>
+    <p class="comment__meta">{{ submitted }}</p>
 
     {#
       Indicate the semantic relationship between parent and child comments for
@@ -89,10 +98,10 @@
     {{ permalink }}
   </footer>
 
-  <div{{ content_attributes }}>
+  <div{{ content_attributes.addClass('comment__content') }}>
     {% if title %}
       {{ title_prefix }}
-      <h3{{ title_attributes }}>{{ title }}</h3>
+      <h3{{ title_attributes.addClass('comment__title') }}>{{ title }}</h3>
       {{ title_suffix }}
     {% endif %}
     {{ content }}


### PR DESCRIPTION
Like so many other spots in this issue, we don't actually need to
preprocess comments to get the classes we want to use on the template.
Doing most of this with Twig now.
