### PR TITLE
Remove unused Flexslider reference in libraries file.

### DIFF
--- a/windup.libraries.yml
+++ b/windup.libraries.yml
@@ -9,10 +9,8 @@ bower:
   js:
     # DO NOT REMOVE OR EDIT BETWEEN THESE LINES
     # bower:js
-    bower_components/flexslider/jquery.flexslider.js: {}
     # endbower
   css:
     compiled:
       # bower:css
-      bower_components/flexslider/flexslider.css: {}
       # endbower


### PR DESCRIPTION
There are two Flexslider references in the libraries file that aren't necessary. 
