### PR TITLE
Admin tabs component: update styles for variable names, prevent sass-lint errors

### DIFF
--- a/scss/component/_admin-tabs.scss
+++ b/scss/component/_admin-tabs.scss
@@ -1,54 +1,62 @@
-.admin-tabs--primary {
-  position: relative;
-  display: flex;
-  flex-wrap: nowrap;
-  flex-flow: flex-start;
-  margin: 0 0 0.5em;
-  padding: 0.5em 1em 0 0.5em;
+$adminTabsBorderColour: #cfcfcf !default;
+$adminTabsLinkColour: #efefef !default;
+$adminTabsLinkActiveHoverColour: #fff !default;
+$adminTabsLinkHoverColour: #e5e5e5 !default;
+$adminTabsBorderWidth: 1px !default;
 
-  &:before {
-    content: '';
-    position: absolute;
-    bottom: 1px;
-    left: 0;
-    z-index: -1;
-    width: 100%;
-    height: 0;
-    border-bottom: 1px solid #cfcfcf;
+.admin-tabs {
+  &--primary {
+    position: relative;
+    display: flex;
+    flex-wrap: nowrap;
+    flex-flow: flex-start;
+    margin: 0 0 0.5em;
+    padding: 0.5em 1em 0 0.5em;
+
+    &:before {
+      content: "";
+      position: absolute;
+      bottom: 1px;
+      left: 0;
+      z-index: -1;
+      width: 100%;
+      height: 0;
+      border-bottom: $adminTabsBorderWidth solid $adminTabsBorderColour;
+    }
   }
 
-}
+  &__tab {
+    list-style: none;
+    margin: 0;
+    padding: 0;
 
-.admin-tabs__tab {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+    &:last-child {
+      .admin-tabs__link {
+        border-right-width: $adminTabsBorderWidth;
+      }
+    }
+  }
 
-.admin-tabs__link {
-  display: block;
-  padding: 0.5em 0.8em;
-  border: 1px solid #cfcfcf;
-  border-right-width: 0;
-  font-weight: bold;
-  background: #efefef;
+  &__link {
+    display: block;
+    padding: 0.5em 0.8em;
+    border: $adminTabsBorderWidth solid $adminTabsBorderColour;
+    border-right-width: 0;
+    font-weight: bold;
+    background: $adminTabsLinkColour;
 
-  &.is-active {
-    border-bottom-width: 0;
+    &.is-active {
+      border-bottom-width: 0;
 
-    &,
-    &:hover {
-      background: #fff;
+      &,
+      &:hover {
+        background: $adminTabsLinkActiveHoverColour;
+      }
+
     }
 
+    &:hover {
+      background: $adminTabsLinkHoverColour;
+    }
   }
-
-  .admin-tabs__tab:last-child & {
-    border-right-width: 1px;
-  }
-
-  &:hover {
-    background: #f5f5f5;
-  }
-
 }


### PR DESCRIPTION
I noticed that the styles in `component/_admin-tabs.scss` cause a number of compile issues with the included sass-lint config.  These fixes fix these errors.
