### PR TITLE
Prevent empty div.tabs

### DIFF
--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -105,7 +105,7 @@
       </div>
     <?php endif; ?>
 
-    <?php if ($tabs): ?><div class="tabs"><?php print render($tabs); ?></div><?php endif; ?>
+    <?php if (!empty($tabs['primary']) || !empty($tabs['secondary'])): ?><div class="tabs"><?php print render($tabs); ?></div><?php endif; ?>
     <?php print render($page['help']); ?>
     <?php if ($action_links): ?>
       <ul class="action-links"><?php print render($action_links); ?></ul>


### PR DESCRIPTION
`$tabs` exists even if there aren't any to show, this if statement is more trustworthy.